### PR TITLE
latest checkbashism from devscripts fixes a regex issue in previous

### DIFF
--- a/lib/checkbashisms
+++ b/lib/checkbashisms
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 
 # This script is essentially copied from /usr/share/lintian/checks/scripts,
 # which is:
@@ -18,10 +18,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use strict;
-use Getopt::Long qw(:config gnu_getopt);
+use warnings;
+use Getopt::Long qw(:config bundling permute no_getopt_compat);
 use File::Temp qw/tempfile/;
 
 sub init_hashes;
@@ -80,7 +81,7 @@ my $status = 0;
 my $makefile = 0;
 my (%bashisms, %string_bashisms, %singlequote_bashisms);
 
-my $LEADIN = qr'(?:(?:^|[`&;(|{])\s*|(?:if|then|do|while|shell)\s+)';
+my $LEADIN = qr'(?:(?:^|[`&;(|{])\s*|(?:(?:if|elif|while)(?:\s+!)?|then|do|shell)\s+)';
 init_hashes;
 
 my @bashisms_keys = sort keys %bashisms;
@@ -138,10 +139,10 @@ foreach my $filename (@ARGV) {
 	next unless ($check_lines_count == -1 or $. <= $check_lines_count);
 
 	if ($. == 1) { # This should be an interpreter line
-	    if (m,^\#!\s*(\S+),) {
+	    if (m,^\#!\s*(?:\S+/env\s+)?(\S+),) {
 		my $interpreter = $1;
 
-		if ($interpreter =~ m,/make$,) {
+		if ($interpreter =~ m,(?:^|/)make$,) {
 		    init_hashes if !$makefile++;
 		    $makefile = 1;
 		} else {
@@ -150,10 +151,10 @@ foreach my $filename (@ARGV) {
 		}
 		next if $opt_force;
 
-		if ($interpreter =~ m,/bash$,) {
+		if ($interpreter =~ m,(?:^|/)bash$,) {
 		    $mode = 1;
 		}
-		elsif ($interpreter !~ m,/(sh|posh)$,) {
+		elsif ($interpreter !~ m,(?:^|/)(sh|dash|posh)$,) {
 ### ksh/zsh?
 		    warn "script $display_filename does not appear to be a /bin/sh script; skipping\n";
 		    $status |= 2;
@@ -547,7 +548,7 @@ sub script_is_evil_and_wrong {
 	    # Finally the whole subexpression may be omitted for scripts
 	    # which do not pass on their parameters (i.e. after re-execing
 	    # they take their parameters (and potentially data) from stdin
-	    .?(\${1:?\+.?)?(\$(\@|\*))?~x) {
+	    .?(\$\{1:?\+.?)?(\$(\@|\*))?~x) {
             $ret = $. - 1;
             last;
         } elsif (/^\s*(\w+)=\$0;/) {
@@ -560,7 +561,7 @@ sub script_is_evil_and_wrong {
 	    # As above
 	    .?\$$var.?\s*
 	    (--\s*)?
-	    .?(\${1:?\+.?)?(\$(\@|\*))?.?\s*\&~x) {
+	    .?(\$\{1:?\+.?)?(\$(\@|\*))?.?\s*\&~x) {
 
 	    $backgrounded = 1;
 	} elsif ($backgrounded and m~
@@ -688,7 +689,7 @@ sub init_hashes {
 	qr'\$\(\([\s\w$*/+-]*\w\-\-.*?\)\)'   => q<'$((n--))' should be '$n; $((n=n-1))'>,
 	qr'\$\(\([\s\w$*/+-]*\-\-\w.*?\)\)'   => q<'$((--n))' should be '$((n=n-1))'>,
 	qr'\$\(\([\s\w$*/+-]*\*\*.*?\)\)'   => q<exponentiation is not POSIX>,
-	$LEADIN . qr'printf\s["\'][^"\']+?%[qb].+?["\']' => q<printf %q|%b>,
+	$LEADIN . qr'printf\s["\'][^"\']*?%q.+?["\']' => q<printf %q>,
     );
 
     %singlequote_bashisms = (


### PR DESCRIPTION
The older checkbashism was generating the following error when attempting to shlint on any file

Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/